### PR TITLE
Add view creation script to package.json

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -11,7 +11,8 @@
     "loadagre": "sequelize db:seed --seed agreement_seed",
     "loaddoc": "sequelize db:seed --seed document_seed",
     "loadrev": "sequelize db:seed --seed review_seed",
-    "initdb": "npm run createdb && npm run loadprof && npm run loadidea && npm run loadagre && npm run loaddoc && npm run loadrev",
+    "createviews": "psql -U postgres -d ideanebulae_dev -f ./db/models/postgres_views.sql -h localhost -p 5432",
+    "initdb": "npm run createdb && npm run loadprof && npm run loadidea && npm run loadagre && npm run loaddoc && npm run loadrev && npm run createviews",
     "deploy": "git subtree push — prefix dist heroku master",
     "start": "npm run build && node dist/server.js",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Added `createviews` to the package.json scripts. This creates the views in Postgres and is automatically executed as the last step in the `initdb` script.